### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+checkout/

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies for building Python
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    wget \
+    curl \
+    llvm \
+    libncurses5-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libffi-dev \
+    liblzma-dev \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pyenv
+# Pyenv rather than a single Python version so we can adapt to the target repo
+RUN curl https://pyenv.run | bash
+
+# Set environment variables for pyenv
+ENV HOME  /root
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Initialize pyenv automatically by adding it to the profile script
+RUN echo 'eval "$(pyenv init --path)"' >> ~/.profile && \
+    echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.profile
+
+# Install multiple versions of Python using pyenv
+RUN pyenv install 3.12 && pyenv install 3.8 && pyenv global 3.12
+
+# Verify Python installation
+RUN python --version && python3 --version
+
+RUN ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+# Using HTTP/1.1 resolved this error on M1 w/ OSX 14.4:
+# "RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly"
+RUN git config --global http.version HTTP/1.1
+
+WORKDIR /app

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,40 @@
+# Mirko.ai Workspace
+
+[Workspace: Base Docker Env Setup](https://github.com/markokraemer/mirko.ai/issues/1)
+
+## Requirements
+* Docker
+
+## Setup
+
+From this `workpace` dir. 
+
+This will build the container and open a shell
+
+```
+# Use -d for detached mode or a separate terminal
+docker-compose up --build -d
+
+# Run a shell
+docker-compose exec dev-env bash
+
+# When done, if detached
+docker-compose down
+```
+
+## Using the docker env
+
+Example usage from the docker shell, checking out a repo and running its tests.
+
+```
+mkdir checkout
+cd checkout
+git clone https://github.com/jxnl/instructor.git
+cd instructor
+pyenv global 3.12
+
+python -m pip install poetry
+poetry install --with dev
+
+OPENAI_API_KEY=X poetry run pytest tests/ -k "not openai"
+```

--- a/workspace/docker-compose.yml
+++ b/workspace/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  dev-env:
+    build: .
+    volumes:
+      - ..:/app
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
First step for the workspace setup (#1). I added to `workspaces/` with a README, Dockerfile and docker-compose.

Using Ubuntu base image, installing pyenv with Python 3.8 and 3.12 by default - mostly to show that we'd be able install a new one on the fly as needed.

Let me know if this seems reasonable. As I understand the next step would be allowing the Python to "drive" this container?