### PR TITLE
CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Run tests
-        run: python -m pytest
+        run: poetry run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: python -m pip install poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Run tests
+        run: python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ description = "Open-source Devin implementation."
 authors = ["null"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "mirko"}]
+packages = [
+    {include = "abilities"},
+    {include = "layers"},
+    {include = "memory"}
+]
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
- Added a github action to run the tests so we'll have that feedback on PR. 
- The "integration" tests (needing Docker) are currently excluded.
- Just runs Python tests now, we can add node when frontend is merged. 

Other things we might add: Type checking, linting, formatting - some of those might be easier to manage in a local workflow and left out of CI, especially formatting.